### PR TITLE
Take out the "red" function.

### DIFF
--- a/doom-todo-ivy.el
+++ b/doom-todo-ivy.el
@@ -72,9 +72,9 @@
                                  "\\):?\\s-*\\(.+\\)")
                          x)
                       (error
-                       (message (red "Error matching task in file: (%s) %s"
-                                      (error-message-string ex)
-                                      (car (split-string x ":"))))
+                       (message "Error matching task in file: (%s) %s"
+                                (error-message-string ex)
+                                (car (split-string x ":")))
                        nil))
                collect `((type . ,(match-string 3 x))
                          (desc . ,(match-string 4 x))


### PR DESCRIPTION
It seems like the "red" function is left over from doom-emacs. The original code was (message! (red ...)) which in doom-emacs would make a red message appear in the echo-area. See: https://github.com/hlissner/doom-emacs/blob/master/core/autoload/message.el .